### PR TITLE
Fix screen scrolling to top when duplicating a theme

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -134,7 +134,7 @@ android {
       dev {
         dimension "app"
         resValue "string", "app_name","Chrono Dev"
-        versionNameSuffix "-dev",
+        // versionNameSuffix "-dev",
         applicationIdSuffix ".free"
       }
     }

--- a/lib/common/widgets/list/custom_list_view.dart
+++ b/lib/common/widgets/list/custom_list_view.dart
@@ -165,6 +165,8 @@ class _CustomListViewState<Item extends ListItem>
     // if (_scrollController.offset == 0) {
     //   _scrollController.jumpTo(1);
     // }
+    print(_controller.computeItemBox(0));
+    if (_itemCardHeight == 0) return;
     _scrollController.animateTo(index * _itemCardHeight,
         duration: const Duration(milliseconds: 250), curve: Curves.easeIn);
   }

--- a/lib/theme/widgets/theme_card.dart
+++ b/lib/theme/widgets/theme_card.dart
@@ -5,14 +5,14 @@ import 'package:flutter/material.dart';
 
 class ThemeCard<Item extends ThemeItem> extends StatelessWidget {
   const ThemeCard({
-    Key? key,
+    super.key,
     required this.themeItem,
     required this.onPressEdit,
     required this.isSelected,
     required this.getThemeFromItem,
     required this.onPressDelete,
     required this.onPressDuplicate,
-  }) : super(key: key);
+  });
 
   final Item themeItem;
   final VoidCallback onPressEdit;


### PR DESCRIPTION
Kinda fixes #28 
Currently, the screen won't scroll at all when duplicating. Ideally, the screen should scroll to the exact location of the duplicated theme.