### PR TITLE
Allow the app to be set as the default app

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
   <uses-permission
     android:name="android.permission.WAKE_LOCK" />
-     <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
+  <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
   <uses-permission
     android:name="android.permission.USE_FULL_SCREEN_INTENT" />
   <!-- <uses-permission -->


### PR DESCRIPTION
Allow the app to be set as the default app, and be openable from system tray clock. Closes #84.
Note: Some versions like MiUI and XOS don't allow this functionality, so this won't work on them.