### PR TITLE
Add support for direct boot

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,17 +8,18 @@
   <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
   <uses-permission
     android:name="android.permission.USE_FULL_SCREEN_INTENT" />
-  <uses-permission
-    android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+  <!-- <uses-permission -->
+  <!--   android:name="android.permission.SYSTEM_ALERT_WINDOW" /> -->
   <uses-permission
     android:name="android.permission.VIBRATE" />
   <uses-permission
     android:name="android.permission.INTERNET" />
   <uses-permission
     android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
-  <!-- For apps with targetSDK=31 (Android 12) -->
+  <!-- For Android 12 and higher -->
   <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"
     android:maxSdkVersion="32" />
+  <!-- For before Android 12 -->
   <uses-permission
     android:name="android.permission.USE_EXACT_ALARM" />
 
@@ -63,7 +64,7 @@
       </intent-filter>
     </activity>
     <!-- Don't delete the meta-data below.
-             This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
+      This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
     <meta-data
       android:name="flutterEmbedding"
       android:value="2" />

--- a/lib/settings/screens/about_screen.dart
+++ b/lib/settings/screens/about_screen.dart
@@ -134,7 +134,7 @@ class AboutScreen extends StatelessWidget {
                                 ),
                               ),
                               Text(
-                                packageInfo?.packageName ?? 'GNU GPL v3.0',
+                                'GNU GPL v3.0',
                                 style: textTheme.bodyMedium?.copyWith(
                                   color:
                                       colorScheme.onBackground.withOpacity(0.6),


### PR DESCRIPTION
Support [direct boot](https://developer.android.com/privacy-and-security/direct-boot). This allows alarms to ring when device is still locked after restart.