### PR TITLE
One Shot Timers

### DIFF
--- a/lib/alarm/logic/alarm_isolate.dart
+++ b/lib/alarm/logic/alarm_isolate.dart
@@ -249,6 +249,15 @@ void stopTimer(int scheduleId, AlarmStopAction action) async {
         RingtonePlayer.playAlarm(alarm);
       }
     }
+    // One-shot timer: delete from storage on dismiss
+    if (timer.shouldDeleteAfterFinishing) {
+      List<ClockTimer> timers = await loadList("timers");
+      timers.removeWhere((t) => t.id == scheduleId);
+      await saveList("timers", timers);
+      // Notify UI isolate that timers list changed
+      SendPort? updatePort = IsolateNameServer.lookupPortByName(updatePortName);
+      updatePort?.send("updateTimers");
+    }
   }
   RingingManager.stopAllTimers();
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -301,6 +301,8 @@
   "@startMelodyAtRandomPosDescription": {},
   "vibrationSetting": "Vibration",
   "@vibrationSetting": {},
+  "timerDeleteAfterFinishingSetting": "Delete After Finishing",
+  "@timerDeleteAfterFinishingSetting": {},
   "audioChannelSetting": "Audio Channel",
   "@audioChannelSetting": {},
   "audioChannelAlarm": "Alarm",

--- a/lib/timer/data/timer_settings_schema.dart
+++ b/lib/timer/data/timer_settings_schema.dart
@@ -92,6 +92,8 @@ SettingGroup timerSettingsSchema = SettingGroup(
         "Vibration",
       ],
     ),
+    SwitchSetting("Delete After Finishing",
+        (context) => AppLocalizations.of(context)!.timerDeleteAfterFinishingSetting, false),
     SliderSetting("Add Length",
         (context) => AppLocalizations.of(context)!.addLengthSetting, 1, 30, 1,
         unit: "minutes", snapLength: 1),

--- a/lib/timer/types/timer.dart
+++ b/lib/timer/types/timer.dart
@@ -52,6 +52,8 @@ class ClockTimer extends CustomizableListItem {
           ? _settings.getSetting("Time To Full Volume").value
           : TimeDuration.zero;
   double get addLength => _settings.getSetting("Add Length").value;
+  bool get shouldDeleteAfterFinishing =>
+      _settings.getSetting("Delete After Finishing").value;
   List<Tag> get tags => _settings.getSetting("Tags").value;
   TimeDuration get duration => _duration;
   TimeDuration get currentDuration => _currentDuration;

--- a/lib/timer/widgets/timer_card.dart
+++ b/lib/timer/widgets/timer_card.dart
@@ -136,6 +136,15 @@ class _TimerCardState extends State<TimerCard> {
                 ],
               ),
             ),
+            if (widget.timer.shouldDeleteAfterFinishing)
+              SizedBox(
+                width: 24,
+                child: Icon(
+                  Icons.delete_outline_rounded,
+                  size: 18,
+                  color: colorScheme.onSurface.withOpacity(0.4),
+                ),
+              ),
             const Spacer(),
             CardEditMenu(actions: [
               if (!widget.timer.isStopped)


### PR DESCRIPTION
## Summary
Add a “Delete After Finishing” option for timers that removes one‑shot timers from storage automatically when they are dismissed. Addresses #433 

## Changes
- **Alarm isolate**
  - After stopping a timer, if `timer.shouldDeleteAfterFinishing` is true:
    - Load the persisted timer list, remove the finished timer, and save the updated list.
    - Notify the UI isolate via `updatePort` (`updateTimers` message) to refresh the timer list.
- **Localization**
  - Added `timerDeleteAfterFinishingSetting` string to `app_en.arb`.
- **Settings schema**
  - Introduced a new `SwitchSetting` named “Delete After Finishing” (default `false`) in `timerSettingsSchema`.
- **Timer model**
  - Exposed `shouldDeleteAfterFinishing` getter that reads the new setting.
- **Timer card UI**
  - Shows a small trash-can icon next to timers that have the one‑shot flag enabled.

## Notes
- **Implementation details:**
  - Deletion happens in the background isolate that controls timer lifecycles, ensuring the UI does not need to manage the removal directly.
  - The UI receives a simple `"updateTimers"` message; existing UI code already handles generic timer‑list refreshes.
 

<img width="540" height="1200" alt="Screenshot_20260524-143244" src="https://github.com/user-attachments/assets/caa8dcdf-ac14-43e5-8525-b51d3732312b" />
<img width="540" height="1200" alt="Screenshot_20260524-143422" src="https://github.com/user-attachments/assets/956c86b0-42d4-4188-ba3a-e71c54be74c5" />
